### PR TITLE
src/pipe.cpp: fixed compile error with gcc 7.2 in Ubuntu 17.10

### DIFF
--- a/src/pipe.cpp
+++ b/src/pipe.cpp
@@ -83,5 +83,6 @@ ssize_t Pipe::read(void *buffer, unsigned int &nbytes)
 void Pipe::signal()
 {
   // TODO: ignoring return of read/write generates warning; maybe relevant for eventloop work...
-  ::write(_fd_write, '\0', 1);
+  char nullc[1] = {'\0'};
+  ::write(_fd_write, nullc, 1);
 }


### PR DESCRIPTION
Not sure if this fix is of interest, but just in case, submitting the PR to your repo.